### PR TITLE
Восстановить тёмную тему на странице с картой

### DIFF
--- a/src/frontend/css/style.css
+++ b/src/frontend/css/style.css
@@ -1,3 +1,6 @@
+.cover-container { /* override for map width */
+    max-width: 100%;
+}
 .map {
     height: 500px;
     width: 100%;

--- a/src/frontend/html/index.html
+++ b/src/frontend/html/index.html
@@ -21,7 +21,7 @@
   
 </head>
 
-<body>
+<body class="d-flex h-100 text-center text-white bg-dark">
   <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
     <header class="mb-auto">
       <div>
@@ -38,6 +38,7 @@
         </nav>
       </div>
     </header>
+    <div id="map" class="map"></div>
   </div>
     <!--
     <div id="js-map" class="map"></div>
@@ -49,7 +50,6 @@
   <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>-->
 
 
-  <div id="map" class="map"></div>
 
   <script src="../JavaScript/leaflet1_7/leaflet.js"></script>
   <script src="../JavaScript/our_map.js"></script>


### PR DESCRIPTION
Достаточно двух вещей:

 * разместить все объекты внутри `<div>` с нужными классами
 * увеличить максимальную ширину этого класса до 100%